### PR TITLE
APM-1699 Custom Data Stores

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,13 +5,15 @@ all: test install
 $(eval $(moduleRules))
 
 install: libauklet.a
-	sudo cp $< $(INSTALL)/$<
+	sudo cp $< $(INSTALL)/lib/libauklet.a
+	sudo cp $< $(INSTALL)/include/libauklet.h
 
 uninstall:
-	sudo rm -f $(INSTALL)/libauklet.a
+	sudo rm -f $(INSTALL)/lib/libauklet.a
+	sudo rm -f $(INSTALL)/include/libauklet.h
 
 libauklet.tgz: libauklet.a
-	tar cz -f $(TARNAME) $< ../LICENSE
+	tar cz -f $(TARNAME) libauklet.a libauklet.h ../LICENSE
 
 libauklet.a: libauklet.o
 	$(AR) rcs $@ $<

--- a/src/agent.c
+++ b/src/agent.c
@@ -9,6 +9,8 @@
 #include "logger.h"
 
 #include <unistd.h>
+#include "libauklet.h"
+
 #include <signal.h>
 #include "buf.h"
 
@@ -82,6 +84,22 @@ __cyg_profile_func_exit(void *fn, void *cs)
 		logprint(sockfd, FATAL, "pop failed");
 		setagentstate(OFF);
 	}
+}
+
+int
+auklet_send(const char *data, size_t size)
+{
+	/* File descriptor 3 is inherited from the Client
+	 * for transmitting custom JSON messages. */
+	int fd = 3;
+	int offset = 0;
+	while (offset < size) {
+		ssize_t wc = write(fd, data + offset, size - offset);
+		if (-1 == wc)
+			return -1;
+		offset += wc;
+	}
+	return offset;
 }
 
 /* private functions */

--- a/src/config.mk
+++ b/src/config.mk
@@ -7,7 +7,7 @@ OC ?= objcopy
 NM ?= nm
 
 # agent library installation path
-INSTALL = /usr/local/lib
+INSTALL = /usr/local
 
 # Overriden by CircleCI to insert built timestamp
 TIMESTAMP ?= 'no timestamp'

--- a/src/libauklet.h
+++ b/src/libauklet.h
@@ -1,0 +1,8 @@
+/* needs unistd.h */
+
+/* auklet_send sends the given data to Auklet.
+ * data must point to a valid JSON message.
+ * If the data could not be sent to the Client,
+ * -1 is returned and errno is set; otherwise,
+ * the number of bytes written is returned. */
+int auklet_send(const char *data, size_t size);


### PR DESCRIPTION
The purpose of this PR is to support APM-1699. It makes the following changes:

- Add `auklet_send` function, wrapping the previous socket interface. The socket is still there, but nobody needs to know about it.
- Add libauklet.h header file exporting `auklet_send`
- Make `make install` install libauklet.h
- Package libauklet.h in libauklet.tgz

As the usage of the agent library is documented in the client repo, expect a [PR there](https://github.com/aukletio/Auklet-Client-C/pull/16).